### PR TITLE
Multiple code improvements - squid:S1171, squid:S1066, squid:S1213, squid:S1301, squid:UselessParenthesesCheck

### DIFF
--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/MainActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/MainActivity.java
@@ -34,6 +34,8 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
                 Intent footerIntent = new Intent(MainActivity.this, PullZoomFooterActivity.class);
                 startActivity(footerIntent);
                 break;
+            default:
+                break;
         }
     }
 }

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomFooterActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomFooterActivity.java
@@ -77,7 +77,7 @@ public class PullZoomFooterActivity extends ActionBarActivity {
 
         //you can also exends RecyclerView.Adapter
         private class PullZoomAdapter extends RecyclerListAdapter{
-            {
+            public PullZoomAdapter() {
                 addViewType(Integer.class, new ViewHolderFactory<PullZoomItemHolder>() {
                     @Override
                     public PullZoomItemHolder onCreateViewHolder(ViewGroup parent) {
@@ -96,6 +96,7 @@ public class PullZoomFooterActivity extends ActionBarActivity {
             private List<Integer> listData ;
 
             public PullZoomAdapter(List<Integer> listData) {
+                this();
                 this.listData = listData;
             }
 

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomHeaderActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomHeaderActivity.java
@@ -68,7 +68,7 @@ public class PullZoomHeaderActivity extends ActionBarActivity {
             });
         }
 
-        private List<Integer> createPullZoomData(){
+        private List<Integer> createPullZoomData() {
             List<Integer> pullZoomData = new ArrayList<>();
             Collections.addAll(pullZoomData,
                     new Integer[]{R.drawable.p1, R.drawable.p2, R.drawable.p3, R.drawable.p4,
@@ -79,8 +79,8 @@ public class PullZoomHeaderActivity extends ActionBarActivity {
         }
 
         //you can also exends RecyclerView.Adapter
-        private class PullZoomAdapter extends RecyclerListAdapter{
-            {
+        private class PullZoomAdapter extends RecyclerListAdapter {
+            public PullZoomAdapter() {
                 addViewType(Integer.class, new ViewHolderFactory<PullZoomItemHolder>() {
                     @Override
                     public PullZoomItemHolder onCreateViewHolder(ViewGroup parent) {
@@ -99,6 +99,7 @@ public class PullZoomHeaderActivity extends ActionBarActivity {
             private List<Integer> listData ;
 
             public PullZoomAdapter(List<Integer> listData) {
+                this();
                 this.listData = listData;
             }
 
@@ -118,7 +119,7 @@ public class PullZoomHeaderActivity extends ActionBarActivity {
                 return listData.size() + 1;
             }
 
-            private class PullZoomHeaderHolder extends RecyclerListAdapter.ViewHolder<Object>{
+            private class PullZoomHeaderHolder extends RecyclerListAdapter.ViewHolder<Object> {
                 private ImageView zoomView ;
                 private ViewGroup zoomHeaderContainer;
 
@@ -138,7 +139,7 @@ public class PullZoomHeaderActivity extends ActionBarActivity {
                 }
             }
 
-            private class PullZoomItemHolder extends RecyclerListAdapter.ViewHolder<Integer>{
+            private class PullZoomItemHolder extends RecyclerListAdapter.ViewHolder<Integer> {
                 private ImageView imageView ;
                 private TextView textView;
                 public PullZoomItemHolder(@NonNull ViewGroup parent) {

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomBaseView.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomBaseView.java
@@ -112,6 +112,8 @@ public abstract class PullZoomBaseView<T extends View> extends LinearLayout {
                     return true;
                 }
                 break;
+            default:
+                break;
         }
         return false;
     }
@@ -161,6 +163,8 @@ public abstract class PullZoomBaseView<T extends View> extends LinearLayout {
             case MotionEvent.ACTION_CANCEL:
                 // do nothing
                 // the reset action will be done in the function onTouchEvent
+                break;
+            default:
                 break;
         }
         return isPullStart;

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomRecyclerView.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomRecyclerView.java
@@ -176,26 +176,24 @@ public class PullZoomRecyclerView extends PullZoomBaseView<RecyclerView> {
         }
 
         public void run() {
-            if (mZoomView != null) {
-                if ((!mIsFinished) && (mScale > 1.0f)) {
-                    // fix PullToZoomView bug  ---dinus
-                    // should not convert the System.currentTimeMillis() to float
-                    // otherwise the value of (System.currentTimeMillis() - mStartTime) will still be zero
-                    float zoomBackProgress = (System.currentTimeMillis() - mStartTime) / (float) mDuration;
-                    ViewGroup.LayoutParams localLayoutParams = mHeaderContainer.getLayoutParams();
+            if (mZoomView != null && (!mIsFinished) && (mScale > 1.0f)) {
+                // fix PullToZoomView bug  ---dinus
+                // should not convert the System.currentTimeMillis() to float
+                // otherwise the value of (System.currentTimeMillis() - mStartTime) will still be zero
+                float zoomBackProgress = (System.currentTimeMillis() - mStartTime) / (float) mDuration;
+                ViewGroup.LayoutParams localLayoutParams = mHeaderContainer.getLayoutParams();
 
-                    if (zoomBackProgress > 1.0f) {
-                        localLayoutParams.height = mHeaderHeight;
-                        mHeaderContainer.setLayoutParams(localLayoutParams);
-                        mIsFinished = true;
-                        return;
-                    }
-
-                    float currentSacle = mScale - (mScale - 1.0F) * sSmoothToTopInterpolator.getInterpolation(zoomBackProgress);
-                    localLayoutParams.height = ((int) (currentSacle * mHeaderHeight));
+                if (zoomBackProgress > 1.0f) {
+                    localLayoutParams.height = mHeaderHeight;
                     mHeaderContainer.setLayoutParams(localLayoutParams);
-                    post(this);
+                    mIsFinished = true;
+                    return;
                 }
+
+                float currentSacle = mScale - (mScale - 1.0F) * sSmoothToTopInterpolator.getInterpolation(zoomBackProgress);
+                localLayoutParams.height = (int) (currentSacle * mHeaderHeight);
+                mHeaderContainer.setLayoutParams(localLayoutParams);
+                post(this);
             }
         }
 
@@ -203,7 +201,7 @@ public class PullZoomRecyclerView extends PullZoomBaseView<RecyclerView> {
             if (mZoomView != null) {
                 mStartTime = System.currentTimeMillis();
                 mDuration = animationDuration;
-                mScale = ((float) (mHeaderContainer.getHeight()) / mHeaderHeight);
+                mScale = (float) mHeaderContainer.getHeight() / mHeaderHeight;
                 mIsFinished = false;
                 post(this);
             }

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/RecyclerListAdapter.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/RecyclerListAdapter.java
@@ -9,6 +9,11 @@ import java.util.HashMap;
 
 public abstract class RecyclerListAdapter<T, VH extends RecyclerListAdapter.ViewHolder<T>> extends RecyclerView.Adapter<VH> {
 
+    public static final Object ITEM_HEADER = new Object() { };
+    public static final Object ITEM_FOOTER = new Object() { };
+    public static final Class<?> TYPE_HEADER = ITEM_HEADER.getClass();
+    public static final Class<?> TYPE_FOOTER = ITEM_FOOTER.getClass();
+
     private HashMap<Class<?>, Integer>          mViewHolderTypeRegistry     = new HashMap<>();
     private HashMap<Integer, ViewHolderFactory> mViewHolderFactoryRegistry  = new HashMap<>();
 
@@ -77,15 +82,15 @@ public abstract class RecyclerListAdapter<T, VH extends RecyclerListAdapter.View
 
         private final View mRootView;
 
-        @SuppressWarnings("unchecked")
-        public <VT extends View> VT getRootView() {
-            return (VT) mRootView;
-        }
-
         public ViewHolder(@NonNull View view) {
             super(view);
             mRootView = view;
             mRootView.setTag(this);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <VT extends View> VT getRootView() {
+            return (VT) mRootView;
         }
 
         public abstract void bind(T item, int position);
@@ -95,10 +100,5 @@ public abstract class RecyclerListAdapter<T, VH extends RecyclerListAdapter.View
     public interface ViewHolderFactory<VH extends ViewHolder> {
         VH onCreateViewHolder(ViewGroup parent);
     }
-
-    public static final Object ITEM_HEADER = new Object() { };
-    public static final Object ITEM_FOOTER = new Object() { };
-    public static final Class<?> TYPE_HEADER = ITEM_HEADER.getClass();
-    public static final Class<?> TYPE_FOOTER = ITEM_FOOTER.getClass();
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1171 - Only static class initializers should be used.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1213 - The members of an interface declaration or class should
appear in a pre-defined order.
squid:S1301 -  "switch" statements should have at least 3 "case" clauses.
squid:UselessParenthesesCheck - Useless parentheses around expressions
should be removed to prevent any misunderstanding.
squid:SwitchLastCaseIsDefaultCheck -  "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1171
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava
