### PR TITLE
Multiple code improvements - squid:MethodCyclomaticComplexity, squid:S134, squid:S1151, squid:S1213, squid:S1186, squid:S1068

### DIFF
--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomActivity.java
@@ -28,8 +28,6 @@ public class PullZoomActivity extends ActionBarActivity {
 
         protected PullZoomRecyclerView mRecyclerView;
 
-        public PullZoomFragment() {}
-
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             return inflater.inflate(R.layout.fragment_pull_zoom_header, container, false);
@@ -56,6 +54,8 @@ public class PullZoomActivity extends ActionBarActivity {
 
         public class PullZoomAdapter extends RecyclerListAdapter {
 
+            protected List<Integer> listData;
+
             public PullZoomAdapter() {
                 addViewType(Integer.class, new ViewHolderFactory<PullZoomItemHolder>() {
                     @Override
@@ -64,8 +64,6 @@ public class PullZoomActivity extends ActionBarActivity {
                     }
                 });
             }
-
-            protected List<Integer> listData ;
 
             @Override
             public Object getItem(int position) {

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomFooterActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomFooterActivity.java
@@ -30,9 +30,6 @@ public class PullZoomFooterActivity extends PullZoomActivity {
      */
     public static class PullZoomFooterFragment extends PullZoomFragment {
 
-        public PullZoomFooterFragment() {
-        }
-
         public static PullZoomFooterFragment newInstance() {
             return new PullZoomFooterFragment();
         }
@@ -59,8 +56,6 @@ public class PullZoomFooterActivity extends PullZoomActivity {
                     }
                 });
             }
-
-            private List<Integer> listData;
 
             public PullZoomFooterAdapter(List<Integer> listData) {
                 this();

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomHeaderActivity.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/PullZoomHeaderActivity.java
@@ -34,9 +34,6 @@ public class PullZoomHeaderActivity extends PullZoomActivity {
      */
     public static class PullZoomHeaderFragment extends PullZoomFragment {
 
-        public PullZoomHeaderFragment() {
-        }
-
         public static PullZoomHeaderFragment newInstance() {
             return new PullZoomHeaderFragment();
         }
@@ -72,8 +69,6 @@ public class PullZoomHeaderActivity extends PullZoomActivity {
                 });
             }
 
-            private List<Integer> listData;
-
             public PullZoomHeaderAdapter(List<Integer> listData) {
                 this();
                 this.listData = listData;
@@ -84,10 +79,7 @@ public class PullZoomHeaderActivity extends PullZoomActivity {
                 if (position == 0) {
                     return ITEM_HEADER;
                 }
-
-                position--;
-
-                return listData.get(position);
+                return listData.get(--position);
             }
 
             @Override

--- a/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomRecyclerView.java
+++ b/app/src/main/java/app/dinus/com/pullzoomrecyclerview/recyclerview/PullZoomRecyclerView.java
@@ -53,9 +53,9 @@ public class PullZoomRecyclerView extends PullZoomBaseView<RecyclerView> {
     @Override
     protected boolean isReadyZoom() {
         if (mModel == ZOOM_HEADER) {
-            return isFirstItemCompletlyVisible();
+            return isFirstItemCompletelyVisible();
         } else if (mModel == ZOOM_FOOTER) {
-            return isLastItemCompletlyVisible();
+            return isLastItemCompletelyVisible();
         }
 
         return false;
@@ -99,30 +99,35 @@ public class PullZoomRecyclerView extends PullZoomBaseView<RecyclerView> {
         this.sSmoothToTopInterpolator = sSmoothToTopInterpolator;
     }
 
-    private boolean isFirstItemCompletlyVisible() {
+    private boolean isFirstItemCompletelyVisible() {
         if (mWrapperView != null) {
             RecyclerView.Adapter adapter = mWrapperView.getAdapter();
-            RecyclerView.LayoutManager mLayoutmanager = mWrapperView.getLayoutManager();
+            RecyclerView.LayoutManager mLayoutManager = mWrapperView.getLayoutManager();
 
             if (null == adapter || adapter.getItemCount() == 0) {
                 return false;
-            } else if (null == mLayoutmanager || mLayoutmanager.getItemCount() == 0){
+            } else if (null == mLayoutManager || mLayoutManager.getItemCount() == 0) {
                 return false;
             } else {
-                int firstVisiblePosition = ((RecyclerView.LayoutParams) mLayoutmanager.getChildAt(0).getLayoutParams()).getViewPosition();
-                if (firstVisiblePosition == 0) {
-                    final View firstVisibleChild = mWrapperView.getChildAt(0);
-                    if (firstVisibleChild != null) {
-                        return firstVisibleChild.getTop() >= mWrapperView.getTop();
-                    }
-                }
+                return checkFirstItemCompletelyVisible(mLayoutManager);
             }
         }
 
         return false;
     }
 
-    private boolean isLastItemCompletlyVisible() {
+    private boolean checkFirstItemCompletelyVisible(RecyclerView.LayoutManager mLayoutManager) {
+        int firstVisiblePosition = ((RecyclerView.LayoutParams) mLayoutManager.getChildAt(0).getLayoutParams()).getViewPosition();
+        if (firstVisiblePosition == 0) {
+            final View firstVisibleChild = mWrapperView.getChildAt(0);
+            if (firstVisibleChild != null) {
+                return firstVisibleChild.getTop() >= mWrapperView.getTop();
+            }
+        }
+        return false;
+    }
+
+    private boolean isLastItemCompletelyVisible() {
         if (mWrapperView != null) {
             RecyclerView.Adapter adapter = mWrapperView.getAdapter();
             RecyclerView.LayoutManager mLayoutmanager = mWrapperView.getLayoutManager();
@@ -132,20 +137,25 @@ public class PullZoomRecyclerView extends PullZoomBaseView<RecyclerView> {
             } else if (null == mLayoutmanager || mLayoutmanager.getItemCount() == 0){
                 return false;
             } else {
-                int lastVisiblePosition = mLayoutmanager.getChildCount() - 1;
-                int currentLastVisiblePosition = ((RecyclerView.LayoutParams) mLayoutmanager.getChildAt(lastVisiblePosition).getLayoutParams()).getViewPosition();
-                if (currentLastVisiblePosition == mLayoutmanager.getItemCount() - 1) {
-                    final View lastVisibleChild = mWrapperView.getChildAt(lastVisiblePosition);
-                    if (lastVisibleChild != null) {
-                        if (mHeaderContainer != null && mHeaderHeight <= 0) {
-                            mHeaderHeight = mHeaderContainer.getMeasuredHeight();
-                        }
-                        return lastVisibleChild.getBottom() <= mWrapperView.getBottom();
-                    }
-                }
+                return checkLastItemCompletelyVisible(mLayoutmanager);
             }
         }
 
+        return false;
+    }
+
+    private boolean checkLastItemCompletelyVisible(RecyclerView.LayoutManager mLayoutmanager) {
+        int lastVisiblePosition = mLayoutmanager.getChildCount() - 1;
+        int currentLastVisiblePosition = ((RecyclerView.LayoutParams) mLayoutmanager.getChildAt(lastVisiblePosition).getLayoutParams()).getViewPosition();
+        if (currentLastVisiblePosition == mLayoutmanager.getItemCount() - 1) {
+            final View lastVisibleChild = mWrapperView.getChildAt(lastVisiblePosition);
+            if (lastVisibleChild != null) {
+                if (mHeaderContainer != null && mHeaderHeight <= 0) {
+                    mHeaderHeight = mHeaderContainer.getMeasuredHeight();
+                }
+                return lastVisibleChild.getBottom() <= mWrapperView.getBottom();
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S134 - Control flow statements "if", "for", "while", "switch" and
"try" should not be nested too deeply.
squid:S1151 - "switch case" clauses should not have too many lines.
squid:S1213 - The members of an interface declaration or class should
appear in a pre-defined order.
squid:S1186 - Methods should not be empty.
squid:S1068 - Unused private fields should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:S1151
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1186
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava
